### PR TITLE
Add 'new' command to generate a misaki project

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,7 @@
   :url "https://github.com/skuro/lein-misaki"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[misaki "0.2.1-beta"]]
+  :dependencies [[misaki "0.2.3-beta"]
+                 [gh-file-reader "0.0.2"]
+                 [clj-text-decoration "0.0.1"]]
   :eval-in-leiningen true)

--- a/src/leiningen/misaki.clj
+++ b/src/leiningen/misaki.clj
@@ -1,12 +1,31 @@
 (ns leiningen.misaki
-  (:use [misaki server config]))
+  (:use [misaki server config])
+  (:require [gh-file-reader.core  :as gh]
+            [text-decoration.core :as td]))
 
 (defn get-current-directory []
   (-> "."
       java.io.File.
       .getCanonicalPath))
 
+(defn misaki-new
+  "Generate a new Misaki project"
+  ([project-name]
+   (misaki-new project-name "default"))
+  ([project-name template-name]
+   (println
+     (str "Generating a misaki project called " project-name
+          " based on the '" template-name "' template."))
+   ; download template
+   (if-not (gh/download
+         (gh/read-content "liquidz" "misaki-showcase"
+                          (str "/templates/" template-name "/files"))
+         project-name)
+     (println (td/red (str "Template '" template-name "' is not found"))))))
+
 (defn ^:no-project-needed misaki
   "Compiles your Misaki sources and starts a local server"
   [project & args]
-  (apply -main (get-current-directory) args))
+  (case (first args)
+    "new" (apply misaki-new (rest args))
+    (apply -main (get-current-directory) args)))


### PR DESCRIPTION
I added 'new' command to generate a misaki project from lein-misaki.

``` sh
# Generate project with default template
lein misaki new PROJECT_NAME

# Generate project with specified template
lein misaki new PROJECT_NAME TEMPLATE_NAME
```

Template files are managed at [misaki-showcase](https://github.com/liquidz/misaki-showcase) repository.
